### PR TITLE
feature/client

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,6 @@
 machine:
   node:
     version: 6.9.4
+
+  services:
+    - redis

--- a/circle.yml
+++ b/circle.yml
@@ -4,3 +4,19 @@ machine:
 
   services:
     - redis
+
+# https://discuss.circleci.com/t/how-to-run-redis-3-2/5815/5
+dependencies:
+  pre:
+    - sudo service redis-server stop
+    - >
+      cd ~ && if [ ! -d "redis-3.2.8" ]; then
+        wget http://download.redis.io/releases/redis-3.2.8.tar.gz
+        tar xzf redis-3.2.8.tar.gz
+        cd redis-3.2.8 && make;
+      fi
+    - cd ~/redis-3.2.8 && sudo make install
+    - sudo sed -i 's/bin/local\/bin/g' /etc/init/redis-server.conf
+    - sudo service redis-server start
+  cache_directories:
+    - ~/redis-3.2.8

--- a/index.js
+++ b/index.js
@@ -98,3 +98,7 @@ const child = () => {
 
 if (!module.parent)
   cluster.isMaster ? master() : child();
+
+module.exports = {
+  Client: require('./src/client/Client')
+};

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "node index.js",
     "startw": "nodemon --watch src/ --watch index.js --watch config.js --exec \"npm start\"",
-    "test": "BUNYAN_LEVEL=ERROR mocha --bail --no-exit --throw-deprecation tests/helper.js 'tests/**/*.test.js'",
+    "test": "API_SECRET=1 BUNYAN_LEVEL=ERROR mocha --bail --no-exit --throw-deprecation tests/helper.js 'tests/**/*.test.js'",
     "testw": "nodemon --watch src/ --watch tests/ --watch config.js --exec \"npm test\"",
     "lint": "eslint src/ tests/ index.js config.js"
   },
@@ -40,6 +40,7 @@
     "curtain-down": "^1.0.0",
     "lodash": "^4.17.2",
     "redis": "^2.6.2",
+    "request": "^2.79.0",
     "restify": "^4.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "eslint": "^3.8.0",
-    "fakeredis": "^0.3.4",
     "mocha": "^3.1.2",
     "supertest": "^2.0.0",
     "testdouble": "^1.9.0"
@@ -39,7 +38,7 @@
     "bunyan": "^1.8.1",
     "curtain-down": "^1.0.0",
     "lodash": "^4.17.2",
-    "redis": "^2.6.2",
+    "redis": "^2.6.5",
     "request": "^2.79.0",
     "restify": "^4.1.1"
   }

--- a/setenv
+++ b/setenv
@@ -1,4 +1,3 @@
-export API_SECRET=right
 NODE_VERSION=v6
 
 nvm ls $NODE_VERSION || nvm install $NODE_VERSION

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -1,0 +1,105 @@
+'use strict';
+
+const url = require('url');
+const {EventEmitter} = require('events');
+const lodash = require('lodash');
+const requestEvents = require('./request-events');
+const config = require('../../config');
+
+// Some events are special, and have nothing to do with our channles,
+// we should not start HTTP request for them. should not monitor them:
+//
+const ignoreChannels = [
+  'newListener',    // EventEmitter's after listener added
+  'removeListener', // EventEmitter's after listener removed
+  'error',          // HTTP request errored
+  'drain'           // All the requests are finished and there are no listeners left.
+];
+
+class Client extends EventEmitter {
+  constructor (id, {
+    secret,
+    agent,
+    protocol = 'http',
+    hostname = 'localhost',
+    port = 3000,
+    pathname = `${config.http.prefix}/events`
+  } = {}) {
+    const normalizedProtocol = protocol.endsWith(':') ? protocol : `${protocol}:`;
+
+    super();
+    this.id = id;
+    this.polls = {}; // channel => Boolean ()
+    this.agent = agent || require(normalizedProtocol.slice(0, -1)).globalAgent;
+    this.apiRoot = url.format({
+      protocol: normalizedProtocol,
+      hostname,
+      port,
+      pathname
+    });
+  }
+
+  emitEvent (event) {
+    const service = event.from;
+    const eventType = event.type;
+    this.emit(service, event);
+    this.emit(`${service}:${eventType}`, event);
+  }
+
+  request (channel, callback) {
+    const options = {
+      uri: this.apiRoot,
+      method: 'get',
+      agent: this.agent,
+      json: true,
+      gzip: true,
+      qs: {
+        secret: this.secret,
+        clientID: this.id,
+        channel
+      }
+    };
+
+    requestEvents(options, callback);
+  }
+
+  checkForDrain () {
+    if (lodash.values(this.polls).every(status => !status))
+      this.emit('drain');
+  }
+
+  startPolling (channel) {
+    if (this.polls[channel])
+      return;
+
+    this.polls[channel] = true;
+
+    this.request(channel, (err, events) => {
+      if (err)
+        this.emit('error', channel, err);
+      else
+        events.forEach(e => this.emitEvent(e));
+
+      this.polls[channel] = false;
+
+      // If there are still listeners for this channel, keep polling.
+      // Otherewise we might be in a situation when all the requests
+      // are finished, appropriated events are emitted, and no one listening.
+      if (this.listenerCount(channel) === 0)
+        return this.checkForDrain();
+
+      process.nextTick(() => this.startPolling(channel));
+    });
+  }
+
+  on (channel, handler) {
+    // TODO
+    // perhaps print warnings of some kind
+    if (!ignoreChannels.includes(channel))
+      this.startPolling(channel);
+
+    super.on(channel, handler);
+  }
+}
+
+module.exports = Client;

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -22,9 +22,12 @@ class Client extends EventEmitter {
     agent,
     protocol = 'http',
     hostname = 'localhost',
-    port = 3000,
+    port = 8000,
     pathname = `${config.http.prefix}/events`
   } = {}) {
+    if ((typeof secret !== 'string') || (secret.length === 0))
+      throw new Error('options.secret must be non-empty string');
+
     const normalizedProtocol = protocol.endsWith(':') ? protocol : `${protocol}:`;
 
     super();

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -8,7 +8,6 @@ const config = require('../../config');
 
 // Some events are special, and have nothing to do with our channles,
 // we should not start HTTP request for them. should not monitor them:
-//
 const ignoreChannels = [
   'newListener',    // EventEmitter's after listener added
   'removeListener', // EventEmitter's after listener removed
@@ -40,13 +39,6 @@ class Client extends EventEmitter {
       port,
       pathname
     });
-  }
-
-  emitEvent (event) {
-    const service = event.from;
-    const eventType = event.type;
-    this.emit(service, event);
-    this.emit(`${service}:${eventType}`, event);
   }
 
   request (channel, callback) {
@@ -81,7 +73,7 @@ class Client extends EventEmitter {
       if (err)
         this.emit('error', channel, err);
       else
-        events.forEach(e => this.emitEvent(e));
+        events.forEach(e => this.emit(channel, e));
 
       this.polls[channel] = false;
 

--- a/src/client/Cursor.js
+++ b/src/client/Cursor.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const util = require('util');
+const lodash = require('lodash');
+
+class Cursor {
+  constructor (channel, {after = null, limit = null} = {}) {
+    if (typeof channel !== 'string' || (channel.length === 0)) {
+      const message = util.format(
+        'new Cursor() requires channel to be non-empty string, got %j (%s)',
+        channel,
+        typeof channel
+      );
+
+      throw new Error(message);
+    }
+
+    this.channel = channel;
+    this.after = after;
+    this.limit = limit;
+  }
+
+  advance (events) {
+    const newestEvent = Array.isArray(events) && (events.length > 0)
+      ? lodash.maxBy(events, event => event.id)
+      : undefined;
+
+    return newestEvent
+      ? new Cursor(this.channel, {limit: this.limit, after: newestEvent.id})
+      : this;
+  }
+
+  toQuery () {
+    const qs = {channel: this.channel};
+
+    if (this.after !== null)
+      qs.after = this.after;
+
+    if (this.limit !== null)
+      qs.limit = this.limit;
+
+    return qs;
+  }
+}
+
+module.exports = Cursor;

--- a/src/client/request-events.js
+++ b/src/client/request-events.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const request = require('request');
+const util = require('util');
+
+module.exports = (options, callback) => {
+  request(options, (err, res, body) => {
+    if (err)
+      return callback(err);
+
+    if (res.statusCode !== 200) {
+      const message = util.format('Http%d: %j', res.statusCode, body);
+      return callback(new Error(message));
+    }
+
+    callback(null, body);
+  });
+};

--- a/src/client/request-events.js
+++ b/src/client/request-events.js
@@ -3,7 +3,16 @@
 const request = require('request');
 const util = require('util');
 
-module.exports = (options, callback) => {
+module.exports = ({apiRoot, secret, agent, clientID}) => (cursor, callback) => {
+  const options = {
+    uri: apiRoot,
+    method: 'get',
+    agent: agent,
+    json: true,
+    gzip: true,
+    qs: Object.assign({secret, clientID}, cursor.toQuery())
+  };
+
   request(options, (err, res, body) => {
     if (err)
       return callback(err);

--- a/src/events.middleware.get.js
+++ b/src/events.middleware.get.js
@@ -14,7 +14,6 @@
 //
 
 const restify = require('restify');
-const eventsStore = require('./events.store');
 const parseGetParams = require('./parse-get-params');
 const pollForEvents = require('./poll-for-events');
 
@@ -31,23 +30,12 @@ const createMiddleware = ({
   pollForEvents(store, poll, params, (err, events) => {
     if (err) {
       log.error(err);
-      return next(convertError(err));
+      return next(err);
     }
 
     res.json(events);
     next();
   });
-};
-
-const convertError = (err) => {
-  return isInvalidContent(err)
-    ? new restify.InvalidContentError(err.message)
-    : err;
-};
-
-const isInvalidContent = (err) => {
-  return err && (err.message === eventsStore.errors.invalidChannel
-    || err.message === eventsStore.errors.invalidAfterId);
 };
 
 module.exports = {createMiddleware};

--- a/src/events.middleware.get.js
+++ b/src/events.middleware.get.js
@@ -14,7 +14,7 @@
 //
 
 const restify = require('restify');
-const parseGetParams = require('./parse-get-params');
+const {parseGetParams} = require('./parse-http-params');
 const pollForEvents = require('./poll-for-events');
 
 const createMiddleware = ({

--- a/src/events.middleware.get.js
+++ b/src/events.middleware.get.js
@@ -13,21 +13,10 @@
 // Reponds with a JSON array of events (see README.md)
 //
 
-const eventsStore = require('./events.store');
-const utils = require('./utils');
 const restify = require('restify');
-
-const toInt = (something, defaultValue = NaN) => {
-  const str = String(something);
-  const int = parseInt(str, 10);
-  const ok = isFinite(int) && (String(int)) === str;
-  return ok ? int : defaultValue;
-};
-
-const parseLimit = (paramValue, {min = 1, max = 100, byDefault = 100} = {}) => {
-  const desired = toInt(paramValue, byDefault);
-  return Math.min(Math.max(min, desired), max);
-};
+const eventsStore = require('./events.store');
+const parseGetParams = require('./parse-get-params');
+const pollForEvents = require('./poll-for-events');
 
 const createMiddleware = ({
   poll = require('./poll'),
@@ -35,55 +24,19 @@ const createMiddleware = ({
   config = require('../config'),
   store
 }) => (req, res, next) => {
+  const params = parseGetParams(req.params);
+  if (params instanceof Error)
+    return next(new restify.InvalidContentError(params.message));
 
-  const {channel, after, limit} = req.params;
-  const afterId = utils.zeroIfNaN(after);
-
-  const loadEvents = (cb) =>
-    store.loadEvents(channel, afterId, parseLimit(limit), cb);
-
-  if (!channel)
-    return next(new restify.InvalidContentError('channel missing'));
-
-  const json = (data) => {
-    res.json(data);
-    next();
-  };
-
-  // Process the outcome of store.loadEvents,
-  // returns true iff the middleware's job is over (next was called).
-  const processLoad = (err, events, minimalEventsCount = 0) => {
-    if (err)
-      return next(convertError(err)), true;
-    else if (events.length >= minimalEventsCount)
-      return json(events), true;
-    else
-      return false;
-  };
-
-  // Process the outcome of poll.listen
-  //  - when a new message is received,
-  //         -> reload and output events.
-  //  - when no new messages are received,
-  //         -> output an empty array
-  const processPoll = (err, message) => {
+  pollForEvents(store, poll, params, (err, events) => {
     if (err) {
       log.error(err);
-      next(new restify.InternalServerError('polling failed'));
+      return next(convertError(err));
     }
-    else {
-      if (message > afterId)
-        loadEvents(processLoad);
-      else
-        json([]); // timeout is not an error but expected behavior
-    }
-  };
 
-  const pollEvents = () =>
-    poll.listen(channel, processPoll);
-
-  loadEvents((err, events) =>
-    (processLoad(err, events, 1) || pollEvents()));
+    res.json(events);
+    next();
+  });
 };
 
 const convertError = (err) => {

--- a/src/events.middleware.post.js
+++ b/src/events.middleware.post.js
@@ -1,19 +1,18 @@
 'use strict';
 
 const restify = require('restify');
-const _ = require('lodash');
+const {parsePostParams} = require('./parse-http-params');
 
 const createMiddleware = ({
   poll = require('./poll'),
   log = require('./logger'),
   store
 }) => (req, res, next) => {
+  const params = parsePostParams(req.body);
+  if (params instanceof Error)
+    return next(new restify.InvalidContentError(params.message));
 
-  const channel = req.body.channel;
-  const event = _.pick(req.body, 'from', 'type', 'data');
-
-  if (!channel)
-    return next(new restify.InvalidContentError('channel missing'));
+  const {channel, event} = params;
 
   store.addEvent(channel, event, (err, event) => {
 

--- a/src/events.middleware.post.js
+++ b/src/events.middleware.post.js
@@ -1,15 +1,5 @@
 'use strict';
 
-// restify middleware that adds an event to a channel
-//
-// Request body is JSON with fields:
-//  - channel: string
-//             channel to load events from
-//  - from, type, data: event properties (see README.md)
-//
-// Reponds with a JSON event with its allocated id
-//
-const eventsStore = require('./events.store');
 const restify = require('restify');
 const _ = require('lodash');
 
@@ -28,7 +18,7 @@ const createMiddleware = ({
   store.addEvent(channel, event, (err, event) => {
 
     if (err)
-      return next(convertError(err));
+      return next(err);
 
     res.json(event);
     next();
@@ -41,16 +31,6 @@ const createMiddleware = ({
         log.error(err, 'poll.trigger failed');
     });
   });
-};
-
-const isInvalidContent = (err) =>
-  err === eventsStore.errors.invalidEvent ||
-  err === eventsStore.errors.invalidChannel;
-
-const convertError = (err) => {
-  return isInvalidContent(err)
-    ? new restify.InvalidContentError(err.message)
-    : err;
 };
 
 module.exports = {createMiddleware};

--- a/src/events.store.js
+++ b/src/events.store.js
@@ -25,8 +25,21 @@ class EventsStore {
     ], callback);
   }
 
-  loadEvents (channel, {clientId, after, limit, afterExplicitlySet}, callback) {
+  _load (channel, after, limit, callback) {
     this.items.loadItems(channel, after, limit, callback);
+  }
+
+  _loadWithLastFetched (clientId, channel, limit, callback) {
+    async.waterfall([
+      (cb) => this.items.getIndex(`last-fetched:${clientId}:${channel}`, cb),
+      (after, cb) => this._load(channel, after, limit, cb)
+    ], callback);
+  }
+
+  loadEvents (channel, {clientId, after, limit, afterExplicitlySet}, callback) {
+    return afterExplicitlySet
+      ? this._load(channel, after, limit, callback)
+      : this._loadWithLastFetched(clientId, channel, limit, callback);
   }
 }
 

--- a/src/events.store.js
+++ b/src/events.store.js
@@ -28,8 +28,8 @@ const createStore = ({
     },
 
   // Retrieve all events from a channel, with ids bigger than the given one
-    loadEvents: (channel, id, limit, callback) => {
-      itemsStore.loadItems(channel, id, limit, callback);
+    loadEvents: (channel, {clientId, after, limit, afterExplicitlySet}, callback) => {
+      itemsStore.loadItems(channel, after, limit, callback);
     }
   };};
 

--- a/src/parse-get-params.js
+++ b/src/parse-get-params.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const toInt = (something, defaultValue = NaN) => {
+  const str = String(something);
+  const int = parseInt(str, 10);
+  const ok = isFinite(int) && (String(int)) === str;
+  return ok ? int : defaultValue;
+};
+
+const toIntWithinRange = ({
+  min = 0,
+  max = Number.MAX_SAFE_INTEGER,
+  byDefault = NaN
+} = {}) => (paramValue) => {
+  const desired = toInt(paramValue, byDefault);
+  if (desired < min) return byDefault;
+  if (desired > max) return byDefault;
+  return desired;
+};
+
+const nonEmptyString = (paramValue, defaultValue = undefined) => {
+  const ok = (typeof paramValue === 'string') && (paramValue.length > 0);
+  return ok ? paramValue : defaultValue;
+};
+
+const parseAfter = toIntWithinRange({min: 0, byDefault: 0});
+const parseLimit = toIntWithinRange({min: 1, max: 100, byDefault: 100});
+
+module.exports = (params = {}) => {
+  const clientId = nonEmptyString(params.clientId);
+  if (!clientId)
+    return new Error('Invalid Client ID');
+
+  const channel = nonEmptyString(params.channel);
+  if (!channel)
+    return new Error('Invalid Channel');
+
+  const after = parseAfter(params.after);
+  const limit = parseLimit(params.limit);
+
+  return {clientId, channel, after, limit};
+};

--- a/src/parse-http-params.js
+++ b/src/parse-http-params.js
@@ -26,7 +26,7 @@ const nonEmptyString = (paramValue, defaultValue = undefined) => {
 const parseAfter = toIntWithinRange({min: 0, byDefault: 0});
 const parseLimit = toIntWithinRange({min: 1, max: 100, byDefault: 100});
 
-module.exports = (params = {}) => {
+const parseGetParams = (params = {}) => {
   const clientId = nonEmptyString(params.clientId);
   if (!clientId)
     return new Error('Invalid Client ID');
@@ -39,4 +39,42 @@ module.exports = (params = {}) => {
   const limit = parseLimit(params.limit);
 
   return {clientId, channel, after, limit};
+};
+
+const parsePostParams = (params = {}) => {
+  const clientId = nonEmptyString(params.clientId);
+  if (!clientId)
+    return new Error('Invalid Client ID');
+
+  const channel = nonEmptyString(params.channel);
+  if (!channel)
+    return new Error('Invalid Channel');
+
+  const from = nonEmptyString(params.from);
+  if (!from)
+    return new Error('Invalid from');
+
+  const type = nonEmptyString(params.type);
+  if (!type)
+    return new Error('Invalid type');
+
+  const hasData = params.hasOwnProperty('data');
+  const data = params.data;
+
+  if (hasData) {
+    const dataOk = data && (typeof data === 'object');
+    if (!dataOk)
+      return new Error('Invalid data');
+  }
+
+  const event = hasData
+    ? {type, from, data}
+    : {type, from};
+
+  return {clientId, channel, event};
+};
+
+module.exports = {
+  parseGetParams,
+  parsePostParams
 };

--- a/src/parse-http-params.js
+++ b/src/parse-http-params.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const hasOwnProperty = (obj, prop) => Object.hasOwnProperty.call(obj, prop);
+
 const toInt = (something, defaultValue = NaN) => {
   const str = String(something);
   const int = parseInt(str, 10);
@@ -38,7 +40,13 @@ const parseGetParams = (params = {}) => {
   const after = parseAfter(params.after);
   const limit = parseLimit(params.limit);
 
-  return {clientId, channel, after, limit};
+  return {
+    clientId,
+    channel,
+    after,
+    limit,
+    afterExplicitlySet: hasOwnProperty(params, 'after')
+  };
 };
 
 const parsePostParams = (params = {}) => {
@@ -58,7 +66,7 @@ const parsePostParams = (params = {}) => {
   if (!type)
     return new Error('Invalid type');
 
-  const hasData = params.hasOwnProperty('data');
+  const hasData = hasOwnProperty(params, 'data');
   const data = params.data;
 
   if (hasData) {

--- a/src/poll-for-events.js
+++ b/src/poll-for-events.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const restify = require('restify');
+
+module.exports = (store, poll, {clientId, channel, after, limit}, callback) => {
+  const loadEvents = (cb) =>
+    store.loadEvents(channel, after, limit, cb);
+
+  // Process the outcome of store.loadEvents,
+  // returns true iff the middleware's job is over (next was called).
+  const processLoad = (err, events, minimalEventsCount = 0) => {
+    if (err) {
+      callback(err);
+      return true;
+    }
+
+    if (events.length >= minimalEventsCount) {
+      callback(null, events);
+      return true;
+    }
+
+    return false;
+  };
+
+  // Process the outcome of poll.listen
+  //  - when a new message is received,
+  //         -> reload and output events.
+  //  - when no new messages are received,
+  //         -> output an empty array
+  const processPoll = (err, message) => {
+    if (err)
+      return callback(new restify.InternalServerError('polling failed'));
+    else {
+      if (message > after)
+        return loadEvents(processLoad);
+      else
+        return processLoad(null, []); // timeout is not an error but expected behavior
+    }
+  };
+
+  const pollEvents = () => poll.listen(channel, processPoll);
+
+  loadEvents((err, events) =>
+    (processLoad(err, events, 1) || pollEvents()));
+};

--- a/src/poll-for-events.js
+++ b/src/poll-for-events.js
@@ -2,9 +2,11 @@
 
 const restify = require('restify');
 
-module.exports = (store, poll, {clientId, channel, after, limit}, callback) => {
+module.exports = (store, poll, params, callback) => {
+  const {after, channel} = params;
+
   const loadEvents = (cb) =>
-    store.loadEvents(channel, after, limit, cb);
+    store.loadEvents(channel, params, cb);
 
   // Process the outcome of store.loadEvents,
   // returns true iff the middleware's job is over (next was called).

--- a/src/redis.store.js
+++ b/src/redis.store.js
@@ -14,6 +14,18 @@ class RedisStore {
     this.redis = redisClient;
   }
 
+  getIndex (key, callback) {
+    this.redis.get(key, (err, int) => {
+      return err
+        ? callback(err)
+        : callback(null, int ? parseInt(int, 10) : 0);
+    });
+  }
+
+  setIndex (key, idx, callback) {
+    this.redis.set(key, String(idx), (err) => callback(err));
+  }
+
   nextIndex (channel, callback) {
     this.redis.incr(`${INDICES}:${channel}`, callback);
   }

--- a/tests/Client/Client.test.js
+++ b/tests/Client/Client.test.js
@@ -1,0 +1,120 @@
+'use strict';
+
+const url = require('url');
+const config = require('../../config');
+
+describe.only('Client', () => {
+  let Client;
+  let requestEvents;
+
+  beforeEach(() => {
+    requestEvents = td.replace('../../src/client/request-events');
+    Client = require('../../src/client/Client');
+  });
+
+  const apiRoot = 'http://localhost:3000/events/v1';
+  const createClient = () => new Client('clientId', Object.assign(
+    {secret: config.secret},
+    url.parse(apiRoot)
+  ));
+
+  it('keeps reqeusting new messages', (done) => {
+    const client = createClient();
+    let nEmits = 0;
+    let nCalls = 0;
+
+    td.when(requestEvents(td.matchers.isA(Object), td.matchers.isA(Function)))
+      .thenDo((opts, cb) => {
+        ++nCalls;
+        setImmediate(cb, null, [
+          {from: 'service', type: 'type'},
+          {from: 'service', type: 'type'},
+        ]);
+      });
+
+    const handler = event => {
+      ++nEmits;
+      if (nEmits === 4) {
+        client.removeListener('service', handler);
+        client.removeListener('service:type', handler);
+        expect(nCalls).to.equal(2);
+      }
+      else if (nEmits > 4)
+        done(new Error('oops too many emits ' + nEmits));
+    };
+
+    client.on('service:type', handler);
+    client.on('service', handler);
+    client.on('drain', done);
+  });
+
+  it('#once() works without rescheduling', (done) => {
+    const client = createClient();
+    const expectedEvent = {from: 'ch', type: 'type'};
+    let nEmits = 0;
+    let nCalls = 0;
+
+    td.when(requestEvents(td.matchers.isA(Object), td.matchers.isA(Function)))
+      .thenDo((opts, cb) => {
+        ++nCalls;
+        setImmediate(cb, null, [
+          expectedEvent,
+          {from: 'ch', type: 'second event that will get "ignored"'}
+        ]);
+      });
+
+    // this gets called first
+    client.once('ch', (event) => {
+      ++nEmits;
+      expect(event).to.equal(expectedEvent);
+      expect(nCalls).to.equal(1);
+      expect(nEmits).to.equal(1);
+    });
+
+    client.once('ch', (event) => {
+      ++nEmits;
+      expect(event).to.equal(expectedEvent);
+    });
+
+    client.once('drain', (event) => {
+      expect(nCalls).to.equal(1);
+      expect(nEmits).to.equal(2);
+      done();
+    });
+  });
+
+  it('subscribing multiple times does not trigger multiple simultaneous requests', (done) => {
+    const client = createClient();
+    const calls = [];
+    let nEmits = 0;
+
+    td.when(requestEvents(td.matchers.isA(Object), td.matchers.isA(Function)))
+      .thenDo((opts, cb) => {
+        calls.push(opts.qs.channel);
+        setImmediate(cb, null, [
+          {from: 'ch', type: 'type'},
+          {from: 'ch2', type: 'type'}
+        ]);
+      });
+
+    const handler = (channel) => {
+      const myself = (event) => {
+        ++nEmits;
+        client.removeListener(channel, myself);
+      };
+
+      return myself;
+    };
+
+    client.on('ch', handler('ch'));                 // 1 (emit because removes after call)
+    client.on('ch:type', handler('ch:type'));       // 1 (emit because removes after call)
+    client.once('ch2', () => ++nEmits);             // 1
+    client.once('ch2:type', () => ++nEmits);        // 1
+
+    client.on('drain', () => {
+      expect(nEmits).to.equal(4);
+      expect(calls).to.eql(['ch', 'ch:type', 'ch2', 'ch2:type']);
+      done();
+    });
+  });
+});

--- a/tests/Client/Client.test.js
+++ b/tests/Client/Client.test.js
@@ -2,29 +2,26 @@
 
 const url = require('url');
 const config = require('../../config');
+const Client = require('../../src/client/Client');
 
 describe('Client', () => {
-  let Client;
-  let requestEvents;
+  const createClient = () => {
+    const client = new Client('clientId', Object.assign(
+      {secret: config.secret},
+      url.parse('http://localhost:3000/events/v1')
+    ));
 
-  beforeEach(() => {
-    requestEvents = td.replace('../../src/client/request-events');
-    Client = require('../../src/client/Client');
-  });
-
-  const apiRoot = 'http://localhost:3000/events/v1';
-  const createClient = () => new Client('clientId', Object.assign(
-    {secret: config.secret},
-    url.parse(apiRoot)
-  ));
+    td.replace(client, 'request', td.function());
+    return client;
+  };
 
   it('keeps reqeusting new messages', (done) => {
     const client = createClient();
     let nEmits = 0;
     let nCalls = 0;
 
-    td.when(requestEvents(td.matchers.isA(Object), td.matchers.isA(Function)))
-      .thenDo((opts, cb) => {
+    td.when(client.request(td.matchers.isA(Object), td.matchers.isA(Function)))
+      .thenDo((cursor, cb) => {
         ++nCalls;
         setImmediate(cb, null, [
           {from: 'service', type: 'type'},
@@ -60,8 +57,8 @@ describe('Client', () => {
     let nEmits = 0;
     let nCalls = 0;
 
-    td.when(requestEvents(td.matchers.isA(Object), td.matchers.isA(Function)))
-      .thenDo((opts, cb) => {
+    td.when(client.request(td.matchers.isA(Object), td.matchers.isA(Function)))
+      .thenDo((cursor, cb) => {
         ++nCalls;
         setImmediate(cb, null, [
           expectedEvent,
@@ -94,9 +91,9 @@ describe('Client', () => {
     const calls = [];
     let nEmits = 0;
 
-    td.when(requestEvents(td.matchers.isA(Object), td.matchers.isA(Function)))
-      .thenDo((opts, cb) => {
-        calls.push(opts.qs.channel);
+    td.when(client.request(td.matchers.isA(Object), td.matchers.isA(Function)))
+      .thenDo((cursor, cb) => {
+        calls.push(cursor.channel);
         setImmediate(cb, null, [
           {from: 'ch', type: 'type'},
           {from: 'ch2', type: 'type'}

--- a/tests/Client/Client.test.js
+++ b/tests/Client/Client.test.js
@@ -34,10 +34,13 @@ describe('Client', () => {
 
     const handler = event => {
       ++nEmits;
-      if (nEmits === 4) {
-        client.removeListener('service', handler);
+      if (nEmits === 2) {
+        // first we receive 2 messages from one channel
         client.removeListener('service:type', handler);
-        expect(nCalls).to.equal(2);
+      }
+      else if (nEmits === 4) {
+        // then 2 messages from another
+        client.removeListener('service', handler);
       }
       else if (nEmits > 4)
         done(new Error('oops too many emits ' + nEmits));
@@ -45,7 +48,10 @@ describe('Client', () => {
 
     client.on('service:type', handler);
     client.on('service', handler);
-    client.on('drain', done);
+    client.on('drain', () => {
+      expect(nCalls).to.equal(2);
+      done();
+    });
   });
 
   it('#once() works without rescheduling', (done) => {

--- a/tests/Client/Client.test.js
+++ b/tests/Client/Client.test.js
@@ -3,7 +3,7 @@
 const url = require('url');
 const config = require('../../config');
 
-describe.only('Client', () => {
+describe('Client', () => {
   let Client;
   let requestEvents;
 

--- a/tests/Client/Cursor.test.js
+++ b/tests/Client/Cursor.test.js
@@ -1,0 +1,81 @@
+'use strict';
+
+const Cursor = require('../../src/client/Cursor');
+
+describe('Cursor', () => {
+  describe('new Cursor()', () => {
+    it('requires channel', () => {
+      expect(() => new Cursor()).to.throw(/requires channel/);
+    });
+
+    it('defaults things', () => {
+      expect(new Cursor('channel')).to.eql({
+        channel: 'channel',
+        after: null,
+        limit: null
+      });
+    });
+
+    it('accepts non-default things', () => {
+      expect(new Cursor('channel', {limit: 50})).to.eql({
+        channel: 'channel',
+        after: null,
+        limit: 50
+      });
+    });
+  });
+
+  describe('#advance()', () => {
+    const start = new Cursor('channel');
+    const events = [{id: 1}, {id: 5}, {id: 2}, {id: 3}];
+
+    it('returns new cursror', () => {
+      const next = start.advance(events);
+      expect(next).to.be.instanceof(Cursor);
+      expect(next).to.not.be.equal(start);
+    });
+
+    it('moves after to max event id', () => {
+      expect(start.advance(events).after).to.equal(5);
+    });
+
+    it('advancing with empty or malformed array returns self', () => {
+      expect(start.advance([])).to.equal(start);
+      expect(start.advance([{}])).to.equal(start);
+    });
+
+    it('advancing with non-array returns self', () => {
+      expect(start.advance(undefined)).to.equal(start);
+      expect(start.advance(null)).to.equal(start);
+      expect(start.advance(new Error())).to.equal(start);
+    });
+  });
+
+  describe('#toQuery()', () => {
+    it('includes channel', () => {
+      expect(new Cursor('channel').toQuery()).to.eql({channel: 'channel'});
+    });
+
+    it('includes after if it is non-null', () => {
+      expect(new Cursor('channel', {after: 40}).toQuery()).to.eql({
+        channel: 'channel',
+        after: 40
+      });
+    });
+
+    it('includes limit if it is non-null', () => {
+      expect(new Cursor('channel', {limit: 99}).toQuery()).to.eql({
+        channel: 'channel',
+        limit: 99
+      });
+    });
+
+    it('includes all non-null things', () => {
+      expect(new Cursor('channel', {after: 40, limit: 99}).toQuery()).to.eql({
+        channel: 'channel',
+        after: 40,
+        limit: 99
+      });
+    });
+  });
+});

--- a/tests/Client/request-events.test.js
+++ b/tests/Client/request-events.test.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const http = require('http');
+const lodash = require('lodash');
+const Cursor = require('../../src/client/Cursor');
+
+describe('request-events', () => {
+  let request;
+  let requestEvents;
+
+  beforeEach(() => {
+    request = td.replace('request', td.function());
+    requestEvents = require('../../src/client/request-events');
+  });
+
+  it('correctly captures things', (done) => {
+    const cursor = new Cursor('channel', {limit: 10});
+    const baseOpts = {
+      apiRoot: 'http://example.com/events',
+      secret: 'qwerty',
+      agent: http.globalAgent,
+      clientID: 'me'
+    };
+
+    const expectedOptions = td.matchers.argThat(arg => {
+      expect(lodash.pick(arg, 'uri', 'method', 'agent', 'qs')).to.eql({
+        uri: 'http://example.com/events',
+        method: 'get',
+        agent: baseOpts.agent,
+        qs: {
+          secret: 'qwerty',
+          clientID: 'me',
+          channel: 'channel',
+          limit: 10
+        }
+      });
+      return true;
+    });
+
+    td.when(request(expectedOptions, td.matchers.isA(Function)))
+      .thenDo((options, cb) => setImmediate(cb, null, {statusCode: 200}, []));
+
+    const fn = requestEvents(baseOpts);
+    fn(cursor, done);
+  });
+});

--- a/tests/events.middleware.get.test.js
+++ b/tests/events.middleware.get.test.js
@@ -32,14 +32,14 @@ describe('events.middleware.get', () => {
   // NON_EMPTY_CHANNEL:
   //  - has 1 event
   testChannels[NON_EMPTY_CHANNEL] = () => {
-    when(store.loadEvents(NON_EMPTY_CHANNEL, anything(), anything()))
+    when(store.loadEvents(NON_EMPTY_CHANNEL, anything()))
       .thenCallback(null, [NON_EMPTY_EVENT]);
   };
 
   // FAILING_LOAD_CHANNEL:
   //  - loading fails with a InternalServerError
   testChannels[FAILING_LOAD_CHANNEL] = () => {
-    when(store.loadEvents(FAILING_LOAD_CHANNEL, anything(), anything()))
+    when(store.loadEvents(FAILING_LOAD_CHANNEL, anything()))
       .thenCallback(new restify.InternalServerError());
   };
 
@@ -47,7 +47,7 @@ describe('events.middleware.get', () => {
   //  - has no events
   //  - polling will fail
   testChannels[FAILING_POLL_CHANNEL] = () => {
-    when(store.loadEvents(FAILING_POLL_CHANNEL, anything(), anything()))
+    when(store.loadEvents(FAILING_POLL_CHANNEL, anything()))
       .thenCallback(null, []);
     when(poll.listen(FAILING_POLL_CHANNEL))
       .thenCallback(new Error('poll.listen failed'));
@@ -57,7 +57,7 @@ describe('events.middleware.get', () => {
   //  - has no events
   //  - polling will timeout
   testChannels[EMPTY_CHANNEL] = () => {
-    when(store.loadEvents(EMPTY_CHANNEL, anything(), anything()))
+    when(store.loadEvents(EMPTY_CHANNEL, anything()))
       .thenCallback(null, []);
     when(poll.listen(EMPTY_CHANNEL))
       .thenCallback(null, null);
@@ -69,12 +69,12 @@ describe('events.middleware.get', () => {
   //  - then it will have 1 event
   testChannels[TRIGGER_CHANNEL] = () => {
 
-    when(store.loadEvents(TRIGGER_CHANNEL, anything(), anything()))
+    when(store.loadEvents(TRIGGER_CHANNEL, anything()))
       .thenCallback(null, []);
 
     when(poll.listen(TRIGGER_CHANNEL, anything()))
       .thenDo((channel, callback) => {
-        when(store.loadEvents(TRIGGER_CHANNEL, anything(), anything()))
+        when(store.loadEvents(TRIGGER_CHANNEL, anything()))
           .thenCallback(null, [TRIGGER_EVENT]);
         callback(null, TRIGGER_EVENT.id);
       });
@@ -84,7 +84,7 @@ describe('events.middleware.get', () => {
   beforeEach(() => {
 
     store = td.object(['loadEvents']);
-    when(store.loadEvents(anything(), anything(), anything()))
+    when(store.loadEvents(anything(), anything()))
       .thenCallback(new Error('unexpected store.loadEvents'));
 
     poll = td.object(['listen']);
@@ -216,7 +216,8 @@ describe('events.middleware.get', () => {
         clientId,
         channel,
         after: 0,
-        limit: 100
+        limit: 100,
+        afterExplicitlySet: false
       });
     });
 
@@ -246,6 +247,11 @@ describe('events.middleware.get', () => {
       t({channel: 42, clientId});
       t({channel: false, clientId});
       t({channel: undefined, clientId});
+    });
+
+    it('afterExplicitlySet is true, when after is found in params', () => {
+      expect(parseGetParams({channel, clientId, after: 1})).to.have.property('afterExplicitlySet', true);
+      expect(parseGetParams({channel, clientId})).to.have.property('afterExplicitlySet', false);
     });
   });
 });

--- a/tests/events.middleware.get.test.js
+++ b/tests/events.middleware.get.test.js
@@ -4,6 +4,7 @@
 
 const td = require('testdouble');
 const restify = require('restify');
+const {parseGetParams} = require('../src/parse-http-params');
 
 const {anything, isA} = td.matchers;
 const {verify, when} = td;
@@ -171,7 +172,6 @@ describe('events.middleware.get', () => {
   });
 
   describe('parseGetParams()', () => {
-    const parseGetParams = require('../src/parse-get-params');
     const clientId = 'test';
     const channel = 'channel';
 

--- a/tests/events.router.test.js
+++ b/tests/events.router.test.js
@@ -4,7 +4,7 @@
   const {expect} = require('chai');
   const supertest = require('supertest');
   const createServer = require('../src/server');
-  const redis = require('fakeredis');
+  const redis = require('redis');
   const router = require('../src/events.router');
   const config = require('../config');
 

--- a/tests/events.store.test.js
+++ b/tests/events.store.test.js
@@ -8,7 +8,7 @@ describe('events.store', () => {
     let actualEvent;
 
     before((done) => {
-      const itemsStore = td.object(['getIndex', 'addItem']);
+      const itemsStore = td.object(['nextIndex', 'addItem']);
       const subject = createStore({itemsStore});
       const expectedHeader = td.matchers.contains({
         id: 5,
@@ -17,7 +17,7 @@ describe('events.store', () => {
 
       td.replace(Date, 'now', () => now);
 
-      td.when(itemsStore.getIndex('channel', td.callback))
+      td.when(itemsStore.nextIndex('channel', td.callback))
         .thenCallback(null, 5);
 
       td.when(itemsStore.addItem('channel', expectedHeader, td.callback))

--- a/tests/events.store.test.js
+++ b/tests/events.store.test.js
@@ -1,326 +1,62 @@
 'use strict';
 
-const {expect} = require('chai');
-const async = require('async');
-const redis = require('fakeredis');
-const eventsStore = require('../src/events.store');
+const {createStore} = require('../src/events.store');
 
 describe('events.store', () => {
+  describe('#addEvent()', () => {
+    const now = Date.now();
+    let actualEvent;
 
-  let redisClient;
-  let store;
-  const limit = 100;
-  const event = {};
-  const afterId = 0;
-  const channel = 'channel';
+    before((done) => {
+      const itemsStore = td.object(['getIndex', 'addItem']);
+      const subject = createStore({itemsStore});
+      const expectedHeader = td.matchers.contains({
+        id: 5,
+        timestamp: now
+      });
 
-  const addEvent = (channel, event) => (callback) =>
-  store.addEvent(channel, event, callback);
+      td.replace(Date, 'now', () => now);
 
-  const addTwoEvents = (channel, event) => [
-    addEvent(channel, event), addEvent(channel, event)];
+      td.when(itemsStore.getIndex('channel', td.callback))
+        .thenCallback(null, 5);
 
-  const addThreeEvents = (channel, event) => [
-    addEvent(channel, event), addEvent(channel, event),
-    addEvent(channel, event)];
+      td.when(itemsStore.addItem('channel', expectedHeader, td.callback))
+        .thenCallback(null);
 
-  const loadEvents = (channel, id) => (callback) =>
-  store.loadEvents(channel, id, limit, callback);
+      subject.addEvent('channel', {from: 'me', type: 'kind', data: {}}, (err, event) => {
+        expect(err).to.be.null;
+        actualEvent = event;
+        done();
+      });
+    });
 
-  beforeEach(done => {
-    redisClient = redis.createClient(0, 'localhost');
-  // TODO: use a mockup
-    const itemsStore = require('../src/redis.store').createStore({redisClient});
-    store = eventsStore.createStore({itemsStore});
-    redisClient.flushdb(done);
+    it('returns object', () => {
+      expect(actualEvent).to.be.ok;
+      expect(actualEvent).to.be.instanceof(Object);
+    });
+
+    it('fills in event ID based on store channel index', () => {
+      expect(actualEvent.id).to.equal(5);
+    });
+
+    it('fills in event timestamp', () => {
+      expect(actualEvent.timestamp).to.equal(now);
+    });
   });
 
-  afterEach(done => {
-    redisClient.flushdb(() => {
-      redisClient.quit();
-      done();
-    });
-  });
+  describe('#loadEvents()', () => {
+    it('calls down to store implementation', (done) => {
+      const itemsStore = td.object(['loadItems']);
+      const subject = createStore({itemsStore});
 
-  describe('.addEvent', () => {
+      td.when(itemsStore.loadItems('ch', 5, 100, td.callback))
+        .thenCallback(null, [1, 2, 3]);
 
-    it('should succeed when event is defined', (done) => {
-      store.addEvent(channel, event, (err, msg) => {
+      subject.loadEvents('ch', 5, 100, (err, events) => {
         expect(err).to.be.null;
+        expect(events).to.eql([1, 2, 3]);
         done();
       });
-    });
-
-    it('should return an error when event is undefined', (done) => {
-      store.addEvent(channel, undefined, (err, msg) => {
-        expect(err).to.not.be.null;
-        done();
-      });
-    });
-
-    it('should return an error when event is null', (done) => {
-      store.addEvent(channel, null, (err, msg) => {
-        expect(err).to.not.be.null;
-        done();
-      });
-    });
-
-    it('should succeed when channel is a string', (done) => {
-      store.addEvent(channel, event, (err, msg) => {
-        expect(err).to.be.null;
-        done();
-      });
-    });
-
-    it('should return an error when channel is undefined', (done) => {
-      store.addEvent(undefined, event, (err, msg) => {
-        expect(err).to.not.be.null;
-        done();
-      });
-    });
-
-    it('should return an error when channel is not a string', (done) => {
-      store.addEvent(0, event, (err, msg) => {
-        expect(err).to.not.be.null;
-        done();
-      });
-    });
-
-    it('should provide new IDs', (done) => {
-      const expects = (err, ids) => {
-        const id0 = ids[0].id;
-        const id1 = ids[1].id;
-        expect(id0).to.equal(1);
-        expect(id1).to.equal(2);
-        done();
-      };
-
-      async.series(addTwoEvents(channel, event), expects);
-    });
-
-    it('should add events to an empty channel', (done) => {
-      const expects = (err, res) => {
-        const events = res[2];
-        expect(events).to.have.lengthOf(2);
-        expect(events[0].id).to.equal(1);
-        expect(events[1].id).to.equal(2);
-        done();
-      };
-
-      async.series(
-      addTwoEvents(channel, event).concat(loadEvents(channel, 0, limit)),
-      expects);
-    });
-
-    it('should add events to separate channels', (done) => {
-      const otherChannel = 'diff/channel';
-      const expects = (err, res) => {
-        const events = res[2];
-        const otherEvents = res[3];
-        expect(events).to.have.lengthOf(1);
-        expect(events[0].id).to.equal(1);
-        expect(otherEvents).to.have.lengthOf(1);
-        expect(otherEvents[0].id).to.equal(1);
-        done();
-      };
-      async.series([
-        addEvent(channel, event),
-        addEvent(otherChannel, event),
-        loadEvents(channel, 0, limit),
-        loadEvents(otherChannel, 0, limit),
-      ], expects);
-    });
-
-  });
-
-
-  describe('.loadEvents', () => {
-
-    it('should not return an error when channel is a string', (done) => {
-      store.loadEvents(channel, afterId, limit, (err, msg) => {
-        expect(err).to.be.null;
-        done();
-      });
-    });
-
-    it('should return an error when channel is undefined', (done) => {
-      store.loadEvents(undefined, afterId, limit, (err, msg) => {
-        expect(err).to.not.be.null;
-        done();
-      });
-    });
-
-    it('should return an error when channel is not a string', (done) => {
-      store.loadEvents(0, afterId, limit, (err, msg) => {
-        expect(err).to.not.be.null;
-        done();
-      });
-    });
-
-    it('should not return an error when after ID is a number', (done) => {
-      store.loadEvents(channel, afterId, limit, (err, msg) => {
-        expect(err).to.be.null;
-        done();
-      });
-    });
-
-    it('should not return an error when after ID is string parseable to number', (done) => {
-      store.loadEvents(channel, '1', limit, (err, msg) => {
-        expect(err).to.be.null;
-        done();
-      });
-    });
-
-    it('should not return an error when after ID is undefined', (done) => {
-      store.loadEvents(channel, undefined, limit, (err, msg) => {
-        expect(err).to.be.null;
-        done();
-      });
-    });
-
-    it('should return an error when after ID is not valid', (done) => {
-      store.loadEvents(channel, 'true', limit, (err, msg) => {
-        expect(err).to.not.be.null;
-        done();
-      });
-    });
-
-    it('should return no event from empty channel', (done) => {
-      store.loadEvents(channel, afterId, limit, (err, events) => {
-        expect(events).to.have.lengthOf(0);
-        done();
-      });
-    });
-
-    it('should return all events from a channel', (done) => {
-      const expects = (err, res) => {
-        const events = res[2];
-        expect(events).to.have.lengthOf(2);
-        expect(events[0].id).to.equal(1);
-        expect(events[1].id).to.equal(2);
-        done();
-      };
-      async.series(
-      addTwoEvents(channel, event)
-        .concat(loadEvents(channel, afterId, limit))
-      , expects);
-    });
-
-    it('should return events only from own channel', (done) => {
-      const otherChannel = 'diff/channel';
-      const expects = (err, res) => {
-        const events = res[2];
-        expect(events).to.have.lengthOf(1);
-        expect(events[0].id).to.equal(1);
-        done();
-      };
-      async.series([
-        addEvent(channel, event),
-        addEvent(otherChannel, event),
-        loadEvents(channel, afterId, limit),
-      ], expects);
-    });
-
-    it('should return no event if after ID is equal to last event', (done) => {
-      const expects = (err, res) => {
-        const events = res[3];
-        expect(events).to.have.lengthOf(0);
-        done();
-      };
-      async.series(
-      addThreeEvents(channel, event)
-        .concat(loadEvents(channel, 3, limit)),
-      expects);
-    });
-
-    it('should return no event if after ID is beyond last event', (done) => {
-      const expects = (err, res) => {
-        expect(res[3]).to.have.lengthOf(0);
-        done();
-      };
-      async.series(
-      addThreeEvents(channel, event)
-        .concat(loadEvents(channel, 4, limit)),
-      expects);
-    });
-
-    it('should return only events after the given ID', (done) => {
-      const expects = (err, res) => {
-        const events = res[3];
-        expect(events).to.have.lengthOf(2);
-        expect(events[0].id).to.equal(2);
-        expect(events[1].id).to.equal(3);
-        done();
-      };
-      async.series(
-      addThreeEvents(channel, event)
-        .concat(loadEvents(channel, 1, limit)),
-      expects);
-    });
-
-    it('should not return an error when limit is a string', (done) => {
-      const expects = (err, res) => {
-        const events = res[3];
-        expect(err).to.be.null;
-        expect(events).to.have.lengthOf(3);
-        done();
-      };
-      async.series(
-      addThreeEvents(channel, event)
-        .concat(loadEvents(channel, afterId, 'random@string')),
-      expects);
-    });
-
-    it('should not return an error when limit is undefined', (done) => {
-      const expects = (err, res) => {
-        const events = res[3];
-        expect(err).to.be.null;
-        expect(events).to.have.lengthOf(3);
-        done();
-      };
-      async.series(
-      addThreeEvents(channel, event)
-        .concat(loadEvents(channel, afterId, undefined)),
-      expects);
-    });
-
-    it('should not return an error when limit is digital null', (done) => {
-      const expects = (err, res) => {
-        const events = res[3];
-        expect(err).to.be.null;
-        expect(events).to.have.lengthOf(3);
-        done();
-      };
-      async.series(
-      addThreeEvents(channel, event)
-        .concat(loadEvents(channel, afterId, 0)),
-      expects);
-    });
-
-    it('should not return an error when limit is null', (done) => {
-      const expects = (err, res) => {
-        const events = res[3];
-        expect(err).to.be.null;
-        expect(events).to.have.lengthOf(3);
-        done();
-      };
-      async.series(
-      addThreeEvents(channel, event)
-        .concat(loadEvents(channel, afterId, null)),
-      expects);
-    });
-
-    it('should not return an error when limit is a number', (done) => {
-      const expects = (err, res) => {
-        const events = res[3];
-        expect(err).to.be.null;
-        expect(events).to.have.lengthOf(3);
-        done();
-      };
-      async.series(
-      addThreeEvents(channel, event)
-        .concat(loadEvents(channel, afterId, limit)),
-      expects);
     });
   });
 });

--- a/tests/events.store.test.js
+++ b/tests/events.store.test.js
@@ -52,7 +52,24 @@ describe('events.store', () => {
       td.when(itemsStore.loadItems('ch', 5, 100, td.callback))
         .thenCallback(null, [1, 2, 3]);
 
-      subject.loadEvents('ch', {after: 5, limit: 100}, (err, events) => {
+      subject.loadEvents('ch', {after: 5, limit: 100, afterExplicitlySet: true}, (err, events) => {
+        expect(err).to.be.null;
+        expect(events).to.eql([1, 2, 3]);
+        done();
+      });
+    });
+
+    it('asks itemsStore for after with clientId', (done) => {
+      const itemsStore = td.object(['getIndex', 'loadItems']);
+      const subject = createStore({itemsStore});
+
+      td.when(itemsStore.getIndex('last-fetched:client:channel', td.callback))
+        .thenCallback(null, 5);
+
+      td.when(itemsStore.loadItems('channel', 5, 99, td.callback))
+        .thenCallback(null, [1, 2, 3]);
+
+      subject.loadEvents('channel', {clientId: 'client', limit: 99}, (err, events) => {
         expect(err).to.be.null;
         expect(events).to.eql([1, 2, 3]);
         done();

--- a/tests/events.store.test.js
+++ b/tests/events.store.test.js
@@ -52,7 +52,7 @@ describe('events.store', () => {
       td.when(itemsStore.loadItems('ch', 5, 100, td.callback))
         .thenCallback(null, [1, 2, 3]);
 
-      subject.loadEvents('ch', 5, 100, (err, events) => {
+      subject.loadEvents('ch', {after: 5, limit: 100}, (err, events) => {
         expect(err).to.be.null;
         expect(events).to.eql([1, 2, 3]);
         done();

--- a/tests/events.store.test.js
+++ b/tests/events.store.test.js
@@ -45,21 +45,22 @@ describe('events.store', () => {
   });
 
   describe('#loadEvents()', () => {
-    it('calls down to store implementation', (done) => {
-      const itemsStore = td.object(['loadItems']);
+    it('updates last fetched index and loads items in case after is explicit', (done) => {
+      const itemsStore = td.object(['setIndex', 'loadItems']);
       const subject = createStore({itemsStore});
 
-      td.when(itemsStore.loadItems('ch', 5, 100, td.callback))
+      td.when(itemsStore.loadItems('channel', 5, 100, td.callback))
         .thenCallback(null, [1, 2, 3]);
 
-      subject.loadEvents('ch', {after: 5, limit: 100, afterExplicitlySet: true}, (err, events) => {
+      subject.loadEvents('channel', {clientId: 'client', after: 5, limit: 100, afterExplicitlySet: true}, (err, events) => {
         expect(err).to.be.null;
         expect(events).to.eql([1, 2, 3]);
+        td.verify(itemsStore.setIndex('last-fetched:client:channel', 5, td.matchers.isA(Function)));
         done();
       });
     });
 
-    it('asks itemsStore for after with clientId', (done) => {
+    it('asks itemsStore for missing `after` with `clientId`', (done) => {
       const itemsStore = td.object(['getIndex', 'loadItems']);
       const subject = createStore({itemsStore});
 

--- a/tests/redis.store.test.js
+++ b/tests/redis.store.test.js
@@ -11,6 +11,30 @@ describe('redis.store', () => {
   after(done => redisClient.flushdb(done));
   after(done => redisClient.quit(done));
 
+  describe('#setIndex()', () => {
+    it('sets key to hold passed index', (done) => {
+      store.setIndex('something', 42, done);
+    });
+  });
+
+  describe('#getIndex()', () => {
+    it('returns number saved under key', (done) => {
+      store.getIndex('something', (err, index) => {
+        expect(err).to.be.null;
+        expect(index).to.equal(42);
+        done();
+      });
+    });
+
+    it('returns 0 for missing keys', (done) => {
+      store.getIndex('missing', (err, index) => {
+        expect(err).to.be.null;
+        expect(index).to.equal(0);
+        done();
+      });
+    });
+  });
+
   describe('#nextIndex()', () => {
     it('returns index for a channel', (done) => {
       const redisClient = td.object(['incr']);

--- a/tests/redis.store.test.js
+++ b/tests/redis.store.test.js
@@ -1,84 +1,62 @@
 'use strict';
 
-const {expect} = require('chai');
 const async = require('async');
-const redis = require('fakeredis');
-const redisStore = require('../src/redis.store');
+const redis = require('redis');
+const {createStore} = require('../src/redis.store');
 
 describe('redis.store', () => {
+  const redisClient = redis.createClient();
+  const store = createStore({redisClient});
 
-  let redisClient;
-  let store;
-  const limit = 100;
-  const item = {};
-  const start = 1;
-  const group = 'group';
+  after(done => redisClient.flushdb(done));
 
-  beforeEach(done => {
-    redisClient = redis.createClient(0, 'localhost');
-    store = redisStore.createStore({redisClient});
-    redisClient.flushdb(done);
-  });
+  describe('#getIndex()', () => {
+    it('returns index for a channel', (done) => {
+      const redisClient = td.object(['incr']);
+      const store = createStore({redisClient});
 
-  afterEach(done => {
-    redisClient.flushdb(() => {
-      redisClient.quit();
-      done();
+      td.when(redisClient.incr('indices:channel', td.callback))
+        .thenCallback(null, 1);
+
+      store.getIndex('channel', done);
     });
   });
 
-  const itemFactory = (data, index) =>
-  Object.assign({}, data, {index});
+  describe('#addItem()', () => {
+    before(done => redisClient.flushdb(done));
+    const id = 1;
 
-  const addItem = (callback) =>
-  store.addItem(group, item, itemFactory, callback);
-
-  describe('.addItem', () => {
-
-    it('should allow parallel use', (done) => {
-      const expects = (err, indices) => {
+    it('saves json string to channel:json.id', (done) => {
+      store.addItem('channel', {id}, (err, results) => {
         expect(err).to.be.null;
-        expect(indices[0].index)
-        .to.not.equal(indices[1])
-        .to.not.equal(indices[2])
-        .to.not.equal(indices[3]);
-        expect(indices[1].index)
-        .to.not.equal(indices[2])
-        .to.not.equal(indices[3]);
-        expect(indices[2].index)
-        .to.not.equal(indices[3]);
-        done();
-      };
-      async.parallel([addItem, addItem, addItem, addItem], expects);
-    });
-
-    it('should provide next index', (done) => {
-      const expects = (err, indices) => {
-        expect(err).to.be.null;
-        expect(indices[1].index).to.equal(indices[0].index + 1);
-        done();
-      };
-      async.series([addItem, addItem], expects);
-    });
-
-  });
-
-  describe('.loadItems', () => {
-
-    it('should succeed when all parameters are defined', (done) => {
-      store.loadItems(group, start, limit, (err, msg) => {
-        expect(err).to.be.null;
+        expect(results).to.eql([
+          'OK', // set okay
+          1     // pushed 1 item
+        ]);
         done();
       });
     });
 
+    it('does not overwrite existing ids', (done) => {
+      store.addItem('channel', {id}, (err, results) => {
+        expect(err).to.be.instanceof(Error);
+        expect(err.message).to.equal('Item already exists');
+        expect(results).to.eql([
+          null,  // no overwrite
+          0      // pushed no items
+        ]);
+        done();
+      });
+    });
   });
 
-  describe('All together now', () => {
-    beforeEach((done) => {
+  describe('#loadItems()', () => {
+    before(done => redisClient.flushdb(done));
+    before((done) => {
+      let currentId = 1;
       async.times(
         7,
-        (id, cb) => store.addItem('channel', {}, itemFactory, cb),
+        (id, cb) => store.addItem('channel', {id: currentId++}, cb),
         done
       );
     });
@@ -94,17 +72,17 @@ describe('redis.store', () => {
         expect(err).to.be.null;
 
         expect(first).to.have.length(1);
-        expect(first[0]).to.have.property('index', 1);
+        expect(first[0]).to.have.property('id', 1);
 
         expect(second).to.have.length(1);
-        expect(second[0]).to.have.property('index', 2);
+        expect(second[0]).to.have.property('id', 2);
 
         expect(twoItems).to.have.length(2);
-        expect(twoItems[0]).to.have.property('index', 4);
-        expect(twoItems[1]).to.have.property('index', 5);
+        expect(twoItems[0]).to.have.property('id', 4);
+        expect(twoItems[1]).to.have.property('id', 5);
 
         expect(limitPastEnd).to.have.length(1);
-        expect(limitPastEnd[0]).to.have.property('index', 7);
+        expect(limitPastEnd[0]).to.have.property('id', 7);
 
         expect(readPastEnd).to.eql([]);
 

--- a/tests/redis.store.test.js
+++ b/tests/redis.store.test.js
@@ -11,7 +11,7 @@ describe('redis.store', () => {
   after(done => redisClient.flushdb(done));
   after(done => redisClient.quit(done));
 
-  describe('#getIndex()', () => {
+  describe('#nextIndex()', () => {
     it('returns index for a channel', (done) => {
       const redisClient = td.object(['incr']);
       const store = createStore({redisClient});
@@ -19,7 +19,7 @@ describe('redis.store', () => {
       td.when(redisClient.incr('indices:channel', td.callback))
         .thenCallback(null, 1);
 
-      store.getIndex('channel', done);
+      store.nextIndex('channel', done);
     });
   });
 

--- a/tests/redis.store.test.js
+++ b/tests/redis.store.test.js
@@ -9,6 +9,7 @@ describe('redis.store', () => {
   const store = createStore({redisClient});
 
   after(done => redisClient.flushdb(done));
+  after(done => redisClient.quit(done));
 
   describe('#getIndex()', () => {
     it('returns index for a channel', (done) => {


### PR DESCRIPTION
`Client` from #3.

Still left (feel free to add stuff):

  - [ ] pushing events
  - [x] supprot for `after` and `limit` (right now, paging is `clientID` based, so #7 is needed)
  - [ ] [FOR LATER] multiple requests are running when 1 could've been enough (listening on "master" like `service` and "sub" like `service:user-added` — 2 requests, but 1 could've been enough)

  - channel can not be named some things:
    ``` js
    // Some events are special, and have nothing to do with our channles,
    // we should not start HTTP request for them. should not monitor them:
    const ignoreChannels = [
      'newListener',    // EventEmitter's after listener added
      'removeListener', // EventEmitter's after listener removed
      'error',          // HTTP request errored
      'drain'           // All the requests are finished and there are no listeners left.
    ];
    ```
  - see #7 about ack